### PR TITLE
[Fix] Grid bloated should be executed earlier to free tiles to prevent crash

### DIFF
--- a/src/ldtk_level_bgs_manager.cpp
+++ b/src/ldtk_level_bgs_manager.cpp
@@ -51,15 +51,16 @@ struct bg_t
     const layer& layer_instance;
     const tile_grid_base& grid;
 
+    bool grid_bloated;
+    bool next_visible;
+    bool force_reload;
+
     tile_grid_base::tile_info oob_tile;
 
     alignas(int) bn::regular_bg_map_cell cells[ROWS * COLUMNS];
     bn::regular_bg_map_item map_item;
     bn::regular_bg_ptr bg_ptr;
     bn::regular_bg_map_ptr map_ptr;
-    bool next_visible;
-    bool force_reload;
-    bool grid_bloated;
 
     bg_t(const level& lv_, const layer& layer_, const bn::fixed_point& cam_applied_pos, const level_bgs_builder&);
 
@@ -158,10 +159,10 @@ void update_callback()
 bg_t::bg_t(const level& lv_, const layer& layer_, const bn::fixed_point& cam_applied_pos,
            const level_bgs_builder& builder)
     : lv(lv_), layer_instance(layer_),
-      grid(layer_.auto_layer_tiles() ? *layer_.auto_layer_tiles() : *layer_.grid_tiles()),
+      grid(layer_.auto_layer_tiles() ? *layer_.auto_layer_tiles() : *layer_.grid_tiles()), grid_bloated(grid.bloated()),
+      next_visible(builder.visible(layer_.identifier())), force_reload(false),
       oob_tile(builder.out_of_bound_tile_info(layer_.identifier())), map_item(cells[0], bn::size(COLUMNS, ROWS)),
-      bg_ptr(init_bg_ptr(layer_, cam_applied_pos, builder)), map_ptr(bg_ptr.map()), next_visible(bg_ptr.visible()),
-      force_reload(false), grid_bloated(grid.bloated())
+      bg_ptr(init_bg_ptr(layer_, cam_applied_pos, builder)), map_ptr(bg_ptr.map())
 {
 }
 


### PR DESCRIPTION
```
[WARN] GBA Debug: - stack trace -
[WARN] GBA Debug: 0x8009b9e - _ZN4ldtk17level_bgs_manager12_GLOBAL__N_14bg_t10reset_rowsEiiii
[WARN] GBA Debug: 0x8009cbe - _ZN4ldtk17level_bgs_manager12_GLOBAL__N_14bg_t15reset_all_cellsERKN2bn13fixed_point_tILi12EEE
[WARN] GBA Debug: 0x8009dd2 - _ZN4ldtk17level_bgs_manager12_GLOBAL__N_14bg_t11init_bg_ptrERKNS_5layerERKN2bn13fixed_point_tILi12EEERKNS_17level_bgs_builderE
[WARN] GBA Debug: 0x800a196 - _ZN4ldtk17level_bgs_manager12_GLOBAL__N_14lv_t9set_levelEONS_17level_bgs_builderE
[WARN] GBA Debug: 0x800a3c6 - _ZN4ldtk17level_bgs_manager6createEONS_17level_bgs_builderE
[WARN] GBA Debug: 0x800a4c8 - _ZN4ldtk13level_bgs_ptr6createERKNS_5levelE
```

